### PR TITLE
Add CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,25 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 05 * * 5
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "2"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
This PR adds the default workflow for CompatHelper as listed at <https://juliaregistries.github.io/CompatHelper.jl/dev/>; except for one thing. I always set the cron job to once a week. Otherwise, your GitHub Actions workflow contains many runs. I've set it to Friday morning. I have it on Saturday morning myself, but am starting to dislike it since a bunch of CompatHelper mails aren't my perfect start of the weekend :stuck_out_tongue: 

Also, it's advisable to setup the `secrets.DOCUMENTER_KEY` via the manual listed at <https://juliaregistries.github.io/CompatHelper.jl/dev/#Instructions-for-setting-up-the-SSH-deploy-key>. When you set that key, a CI job will automatically run for a new compat entry. (For example, see https://github.com/StatisticalRethinkingJulia/TuringModels.jl/pull/73). If you don't want that, just remove/comment out the last line from `CompatHelper.yml`.