### PR TITLE
Add TagBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
This PR adds TagBot (https://github.com/marketplace/actions/julia-tagbot). Also here, you can remove the private key if you want. The private key is only useful if you also use Documenter.jl to generate documentation.

EDIT: TagBot is very convenient because it automatically tag releases when you trigger a new version for your package in the Julia registry.